### PR TITLE
compatibility fixes for R55

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -40,6 +40,7 @@ in
     mvtools = prev.vapoursynth-mvtools;
     nnedi3 = prev.callPackage ./plugins/nnedi3 { };
     nnedi3cl = prev.callPackage ./plugins/nnedi3cl { };
+    ocr = prev.callPackage ./plugins/ocr { };
     placebo = prev.callPackage ./plugins/placebo { };
     readmpls = prev.callPackage ./plugins/readmpls { };
     remap = prev.callPackage ./plugins/remap { };

--- a/default.nix
+++ b/default.nix
@@ -32,6 +32,7 @@ in
     fmtconv = prev.callPackage ./plugins/fmtconv { };
     histogram = prev.callPackage ./plugins/histogram { };
     hqdn3d = prev.callPackage ./plugins/hqdn3d { };
+    imwri = prev.callPackage ./plugins/imwri { };
     knlmeanscl = prev.callPackage ./plugins/knlmeanscl { };
     lsmashsource = prev.callPackage ./plugins/lsmashsource { };
     median = prev.callPackage ./plugins/median { };

--- a/default.nix
+++ b/default.nix
@@ -8,6 +8,7 @@ in
     addgrain = prev.callPackage ./plugins/addgrain { };
     autocrop = prev.callPackage ./plugins/autocrop { };
     awarpsharp2 = prev.callPackage ./plugins/awarpsharp2 { };
+    bestaudiosource = prev.callPackage ./plugins/bestaudiosource { };
     beziercurve = prev.callPackage ./plugins/beziercurve { };
     bifrost = prev.callPackage ./plugins/bifrost { };
     bilateral = prev.callPackage ./plugins/bilateral { };

--- a/default.nix
+++ b/default.nix
@@ -37,6 +37,7 @@ in
     knlmeanscl = prev.callPackage ./plugins/knlmeanscl { };
     lsmashsource = prev.callPackage ./plugins/lsmashsource { };
     median = prev.callPackage ./plugins/median { };
+    miscfilters-obsolete = prev.callPackage ./plugins/miscfilters-obsolete { };
     msmoosh = prev.callPackage ./plugins/msmoosh { };
     mvtools = prev.vapoursynth-mvtools;
     nnedi3 = prev.callPackage ./plugins/nnedi3 { };

--- a/default.nix
+++ b/default.nix
@@ -43,6 +43,7 @@ in
     placebo = prev.callPackage ./plugins/placebo { };
     readmpls = prev.callPackage ./plugins/readmpls { };
     remap = prev.callPackage ./plugins/remap { };
+    removegrain = prev.callPackage ./plugins/removegrain { };
     retinex = prev.callPackage ./plugins/retinex { };
     sangnom = prev.callPackage ./plugins/sangnom { };
     scxvid = prev.callPackage ./plugins/scxvid { };

--- a/default.nix
+++ b/default.nix
@@ -51,6 +51,7 @@ in
     tcanny = prev.callPackage ./plugins/tcanny { };
     tnlmeans = prev.callPackage ./plugins/tnlmeans { };
     ttempsmooth = prev.callPackage ./plugins/ttempsmooth { };
+    vivtc = prev.callPackage ./plugins/vivtc { };
     wwxd = prev.callPackage ./plugins/wwxd { };
     znedi3 = prev.callPackage ./plugins/znedi3 { };
 

--- a/default.nix
+++ b/default.nix
@@ -48,6 +48,7 @@ in
     retinex = prev.callPackage ./plugins/retinex { };
     sangnom = prev.callPackage ./plugins/sangnom { };
     scxvid = prev.callPackage ./plugins/scxvid { };
+    subtext = prev.callPackage ./plugins/subtext { };
     tcanny = prev.callPackage ./plugins/tcanny { };
     tnlmeans = prev.callPackage ./plugins/tnlmeans { };
     ttempsmooth = prev.callPackage ./plugins/ttempsmooth { };

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1620901170,
-        "narHash": "sha256-hsJnA0fH6gGzj9KOoolUR+8mw+wNAJC/2SxjZsEq1AI=",
+        "lastModified": 1653407748,
+        "narHash": "sha256-g9puJaILRTb9ttlLQ7IehpV7Wcy0n+vs8LOFu6ylQcM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d1601a40c48426ae460eede1675fd1d6ee23e198",
+        "rev": "5ce6597eca7d7b518c03ecda57d45f9404b5e060",
         "type": "github"
       },
       "original": {

--- a/plugins/adjust/default.nix
+++ b/plugins/adjust/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, python3, vapoursynth }:
+{ lib, buildPythonPackage, fetchFromGitHub, fetchpatch, python3, vapoursynth }:
 
 buildPythonPackage rec {
   pname = "vapoursynth-adjust";
@@ -10,6 +10,13 @@ buildPythonPackage rec {
     rev = "v${version}";
     sha256 = "0wd6sh788ljb4vj6fd5zv2cx7nl6x1k3lnz44n7p3ac5vfskjz8a";
   };
+
+  patches = [
+    (fetchpatch {
+      url = "https://github.com/dubhater/vapoursynth-adjust/commit/a3af7cb57cb37747b0667346375536e65b1fed17.patch";
+      sha256 = "sha256-0N7oSsYj0/F0PwswI+1hgM7Gu1KKWdlJOuYf24wlEUw=";
+    })
+  ];
 
   format = "other";
 

--- a/plugins/adjust/default.nix
+++ b/plugins/adjust/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, fetchpatch, python3, vapoursynth }:
+{ lib, buildPythonPackage, fetchFromGitHub, fetchpatch, python, vapoursynth }:
 
 buildPythonPackage rec {
   pname = "vapoursynth-adjust";
@@ -21,12 +21,12 @@ buildPythonPackage rec {
   format = "other";
 
   installPhase = ''
-    install -D adjust.py $out/${python3.sitePackages}/adjust.py
+    install -D adjust.py $out/${python.sitePackages}/adjust.py
   '';
 
   checkInputs = [ vapoursynth ];
   checkPhase = ''
-    PYTHONPATH=$out/${python3.sitePackages}:$PYTHONPATH
+    PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
   '';
   pythonImportsCheck = [ "adjust" ];
 

--- a/plugins/bestaudiosource/0001-Fix-audio-source-iteration-with-Wsign-compare.patch
+++ b/plugins/bestaudiosource/0001-Fix-audio-source-iteration-with-Wsign-compare.patch
@@ -1,0 +1,58 @@
+From 060ebbed04ba4ce351c4f9f641308e1b84ee30f5 Mon Sep 17 00:00:00 2001
+From: Simon Bruder <simon@sbruder.de>
+Date: Mon, 25 Apr 2022 11:33:22 +0200
+Subject: [PATCH] Fix audio source iteration with -Wsign-compare
+
+---
+ src/audiosource.cpp | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/src/audiosource.cpp b/src/audiosource.cpp
+index 9d34f47..88d9820 100644
+--- a/src/audiosource.cpp
++++ b/src/audiosource.cpp
+@@ -292,7 +292,7 @@ bool BestAudioSource::GetExactDuration() {
+     if (HasExactNumAudioSamples)
+         return true;
+     int Index = -1;
+-    for (int i = 0; i < MaxAudioSources; i++) {
++    for (size_t i = 0; i < MaxAudioSources; i++) {
+         if (Decoders[i] && (Index < 0 || Decoders[Index]->GetFrameNumber() < Decoders[i]->GetFrameNumber()))
+             Index = i;
+     }
+@@ -386,14 +386,14 @@ void BestAudioSource::GetAudio(uint8_t * const * const Data, int64_t Start, int6
+         return;
+ 
+     int Index = -1;
+-    for (int i = 0; i < MaxAudioSources; i++) {
++    for (size_t i = 0; i < MaxAudioSources; i++) {
+         if (Decoders[i] && Decoders[i]->GetSamplePosition() <= Start && (Index < 0 || Decoders[Index]->GetSamplePosition() < Decoders[i]->GetSamplePosition()))
+             Index = i;
+     }
+ 
+     // If an empty slot exists simply spawn a new decoder there
+     if (Index < 0) {
+-        for (int i = 0; i < MaxAudioSources; i++) {
++        for (size_t i = 0; i < MaxAudioSources; i++) {
+             if (!Decoders[i]) {
+                 Index = i;
+                 Decoders[i] = new LWAudioDecoder(Source.c_str(), Track, FFOptions);
+@@ -405,7 +405,7 @@ void BestAudioSource::GetAudio(uint8_t * const * const Data, int64_t Start, int6
+     // No far enough back decoder exists and all slots are occupied so evict a random one
+     if (Index < 0) {
+         Index = 0;
+-        for (int i = 0; i < MaxAudioSources; i++) {
++        for (size_t i = 0; i < MaxAudioSources; i++) {
+             if (Decoders[i] && DecoderLastUse[i] < DecoderLastUse[Index])
+                 Index = i;
+         }
+@@ -458,4 +458,4 @@ void BestAudioSource::GetAudio(uint8_t * const * const Data, int64_t Start, int6
+ 
+     if (Count != 0)
+         throw AudioException("Code error, failed to provide all samples");
+-}
+\ No newline at end of file
++}
+-- 
+2.33.1
+

--- a/plugins/bestaudiosource/default.nix
+++ b/plugins/bestaudiosource/default.nix
@@ -1,0 +1,33 @@
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, ffmpeg, vapoursynth }:
+
+stdenv.mkDerivation rec {
+  pname = "bestaudiosource";
+  version = "unstable-2021-09-28";
+
+  src = fetchFromGitHub {
+    owner = "vapoursynth";
+    repo = pname;
+    rev = "87d6cba4a119f347e146de8f9751646b6f21284c";
+    sha256 = "sha256-ylNPv/QOBcJk6QTuXL/W6kJGJ+7Yg7WEFS5HEp7AIYY=";
+  };
+
+  patches = [
+    ./0001-Fix-audio-source-iteration-with-Wsign-compare.patch
+  ];
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+  buildInputs = [ ffmpeg vapoursynth ];
+
+  postPatch = ''
+    substituteInPlace meson.build \
+        --replace "vapoursynth_dep.get_pkgconfig_variable('libdir')" "get_option('libdir')"
+  '';
+
+  meta = with lib; {
+    description = "Audio source and FFmpeg wrapper plugin for VapourSynth";
+    homepage = "https://github.com/vapoursynth/bestaudiosource";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sbruder ];
+    platforms = platforms.all;
+  };
+}

--- a/plugins/bm3d/default.nix
+++ b/plugins/bm3d/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "vapoursynth-bm3d";
-  version = "r8";
+  version = "r9";
 
   src = fetchFromGitHub {
     owner = "HomeOfVapourSynthEvolution";
     repo = "VapourSynth-BM3D";
     rev = version;
-    sha256 = "0hifiyqr0vp3rkqrjbz2fvka7s8xvcpl58rjf0rvljs64bxia4v7";
+    sha256 = "sha256-i7Kk7uFt2Wo/EWpVkGyuYgGZxBuQgOT3JM+WCFPHVrc=";
   };
 
   nativeBuildInputs = [ meson ninja pkg-config ];

--- a/plugins/debandshit/default.nix
+++ b/plugins/debandshit/default.nix
@@ -1,4 +1,4 @@
-{ lib, vapoursynthPlugins, buildPythonPackage, fetchFromGitHub, python3, vapoursynth }:
+{ lib, vapoursynthPlugins, buildPythonPackage, fetchFromGitHub, python, vapoursynth }:
 let
   propagatedBinaryPlugins = with vapoursynthPlugins; [
     f3kdb
@@ -27,14 +27,14 @@ buildPythonPackage rec {
 
   installPhase = ''
     runHook preInstall
-    install -D debandshit.py $out/${python3.sitePackages}/debandshit.py
+    install -D debandshit.py $out/${python.sitePackages}/debandshit.py
     runHook postInstall
   '';
 
   checkInputs = [ (vapoursynth.withPlugins propagatedBinaryPlugins) ];
   checkPhase = ''
     runHook preCheck
-    PYTHONPATH=$out/${python3.sitePackages}:$PYTHONPATH
+    PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
     runHook postCheck
   '';
   pythonImportsCheck = [ "debandshit" ];

--- a/plugins/descale/default.nix
+++ b/plugins/descale/default.nix
@@ -1,7 +1,7 @@
-{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, vapoursynth, python3 }:
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, vapoursynth, python }:
 
-# required to make python3.buildEnv use descale’s python module
-python3.pkgs.toPythonModule (stdenv.mkDerivation rec {
+# required to make python.buildEnv use descale’s python module
+python.pkgs.toPythonModule (stdenv.mkDerivation rec {
   pname = "vapoursynth-descale";
   version = "r6";
 
@@ -21,7 +21,7 @@ python3.pkgs.toPythonModule (stdenv.mkDerivation rec {
   '';
 
   postInstall = ''
-    install -D ../descale.py $out/${python3.sitePackages}/descale.py
+    install -D ../descale.py $out/${python.sitePackages}/descale.py
   '';
 
   meta = with lib; {

--- a/plugins/edi_rpow2/0001-Use-vs.core-instead-of-vs.get_core.patch
+++ b/plugins/edi_rpow2/0001-Use-vs.core-instead-of-vs.get_core.patch
@@ -1,0 +1,79 @@
+From 90fa697e44d42e7939071672a7ae282be7d37ca9 Mon Sep 17 00:00:00 2001
+From: Simon Bruder <simon@sbruder.de>
+Date: Sun, 17 Oct 2021 11:38:12 +0200
+Subject: [PATCH] Use vs.core instead of vs.get_core()
+
+The latter has been removed since VapourSynth R55.
+---
+ edi_rpow2.py | 14 +++++++-------
+ 1 file changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/edi_rpow2.py b/edi_rpow2.py
+index 6aedea9..cd345bd 100644
+--- a/edi_rpow2.py
++++ b/edi_rpow2.py
+@@ -1,6 +1,6 @@
+ def nnedi3_rpow2(clip,rfactor,correct_shift="zimg",nsize=0,nns=3,qual=None,etype=None,pscrn=None,opt=None,int16_prescreener=None,int16_predictor=None,exp=None):
+ 	import vapoursynth as vs
+-	core = vs.get_core()
++	core = vs.core
+ 	
+ 	def edi(clip,field,dh):
+ 		return core.nnedi3.nnedi3(clip=clip,field=field,dh=dh,nsize=nsize,nns=nns,qual=qual,etype=etype,pscrn=pscrn,opt=opt,int16_prescreener=int16_prescreener,int16_predictor=int16_predictor,exp=exp)
+@@ -9,7 +9,7 @@ def nnedi3_rpow2(clip,rfactor,correct_shift="zimg",nsize=0,nns=3,qual=None,etype
+ 
+ def znedi3_rpow2(clip,rfactor,correct_shift="zimg",nsize=0,nns=3,qual=None,etype=None,pscrn=None,opt=None,int16_prescreener=None,int16_predictor=None,exp=None):
+ 	import vapoursynth as vs
+-	core = vs.get_core()
++	core = vs.core
+ 	
+ 	def edi(clip,field,dh):
+ 		return core.znedi3.nnedi3(clip=clip,field=field,dh=dh,nsize=nsize,nns=nns,qual=qual,etype=etype,pscrn=pscrn,opt=opt,int16_prescreener=int16_prescreener,int16_predictor=int16_predictor,exp=exp)
+@@ -18,7 +18,7 @@ def znedi3_rpow2(clip,rfactor,correct_shift="zimg",nsize=0,nns=3,qual=None,etype
+ 
+ def nnedi3cl_rpow2(clip,rfactor,correct_shift="zimg",nsize=0,nns=3,qual=None,etype=None,pscrn=None,device=None):
+ 	import vapoursynth as vs
+-	core = vs.get_core()
++	core = vs.core
+ 	
+ 	def edi(clip,field,dh):
+ 		return core.nnedi3cl.NNEDI3CL(clip=clip,field=field,dh=dh,nsize=nsize,nns=nns,qual=qual,etype=etype,pscrn=pscrn,device=device)
+@@ -27,7 +27,7 @@ def nnedi3cl_rpow2(clip,rfactor,correct_shift="zimg",nsize=0,nns=3,qual=None,ety
+ 
+ def eedi3_rpow2(clip,rfactor,correct_shift="zimg",alpha=None,beta=None,gamma=None,nrad=None,mdis=None,hp=None,ucubic=None,cost3=None,vcheck=None,vthresh0=None,vthresh1=None,vthresh2=None,sclip=None):
+ 	import vapoursynth as vs
+-	core = vs.get_core()
++	core = vs.core
+ 	
+ 	def edi(clip,field,dh):
+ 		return core.eedi3.eedi3(clip=clip,field=field,dh=dh,alpha=alpha,beta=beta,gamma=gamma,nrad=nrad,mdis=mdis,hp=hp,ucubic=ucubic,cost3=cost3,vcheck=vcheck,vthresh0=vthresh0,vthresh1=vthresh1,vthresh2=vthresh2,sclip=sclip)
+@@ -36,7 +36,7 @@ def eedi3_rpow2(clip,rfactor,correct_shift="zimg",alpha=None,beta=None,gamma=Non
+ 
+ def eedi2_rpow2(clip,rfactor,correct_shift="zimg",mthresh=None,lthresh=None,vthresh=None,estr=None,dstr=None,maxd=None,map=None,nt=None,pp=None):
+ 	import vapoursynth as vs
+-	core = vs.get_core()
++	core = vs.core
+ 	
+ 	def edi(clip,field,dh):
+ 		return core.eedi2.EEDI2(clip=clip,field=field,mthresh=mthresh,lthresh=lthresh,vthresh=vthresh,estr=estr,dstr=dstr,maxd=maxd,map=map,nt=nt,pp=pp)
+@@ -46,7 +46,7 @@ def eedi2_rpow2(clip,rfactor,correct_shift="zimg",mthresh=None,lthresh=None,vthr
+ def edi_rpow2(clip,rfactor,correct_shift,edi):
+ 	import vapoursynth as vs
+ 	import math
+-	core = vs.get_core()
++	core = vs.core
+ 	
+ 	steps=math.log(rfactor)/math.log(2) # 2^steps=rfactor
+ 	
+@@ -74,7 +74,7 @@ def edi_rpow2(clip,rfactor,correct_shift,edi):
+ 
+ def correct_edi_shift(clip,rfactor,plugin):
+ 	import vapoursynth as vs
+-	core = vs.get_core()
++	core = vs.core
+ 	
+ 	if clip.format.subsampling_w==1:
+ 		hshift=-rfactor/2+0.5 # hshift(steps+1)=2*hshift(steps)-0.5
+-- 
+2.31.1
+

--- a/plugins/edi_rpow2/default.nix
+++ b/plugins/edi_rpow2/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchgit, vapoursynthPlugins, python3, vapoursynth }:
+{ lib, buildPythonPackage, fetchgit, vapoursynthPlugins, python, vapoursynth }:
 
 buildPythonPackage rec {
   pname = "edi_rpow2";
@@ -26,12 +26,12 @@ buildPythonPackage rec {
   format = "other";
 
   installPhase = ''
-    install -D edi_rpow2.py $out/${python3.sitePackages}/edi_rpow2.py
+    install -D edi_rpow2.py $out/${python.sitePackages}/edi_rpow2.py
   '';
 
   checkInputs = [ (vapoursynth.withPlugins propagatedBuildInputs) ];
   checkPhase = ''
-    PYTHONPATH=$out/${python3.sitePackages}:$PYTHONPATH
+    PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
   '';
   pythonImportsCheck = [ "edi_rpow2" ];
 

--- a/plugins/edi_rpow2/default.nix
+++ b/plugins/edi_rpow2/default.nix
@@ -10,6 +10,10 @@ buildPythonPackage rec {
     sha256 = "0vaj4v74khrsmyvkpimfkbbyk4bwn065j57fcvzx37fki8a8sw6i";
   };
 
+  patches = [
+    ./0001-Use-vs.core-instead-of-vs.get_core.patch
+  ];
+
   propagatedBuildInputs = with vapoursynthPlugins; [
     eedi2
     eedi3m

--- a/plugins/finedehalo/default.nix
+++ b/plugins/finedehalo/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchgit, vapoursynthPlugins, python3, vapoursynth }:
+{ lib, buildPythonPackage, fetchgit, vapoursynthPlugins, python, vapoursynth }:
 
 buildPythonPackage rec {
   pname = "finedehalo";
@@ -19,14 +19,14 @@ buildPythonPackage rec {
 
   installPhase = ''
     runHook preInstall
-    install -D finedehalo.py $out/${python3.sitePackages}/finedehalo.py
+    install -D finedehalo.py $out/${python.sitePackages}/finedehalo.py
     runHook postInstall
   '';
 
   checkInputs = [ vapoursynth ];
   checkPhase = ''
     runHook preCheck
-    PYTHONPATH=$out/${python3.sitePackages}:$PYTHONPATH
+    PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
     runHook postCheck
   '';
   pythonImportsCheck = [ "finedehalo" ];

--- a/plugins/fmtconv/default.nix
+++ b/plugins/fmtconv/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation rec {
   pname = "fmtconv";
-  version = "r22";
+  version = "r29";
 
   src = fetchFromGitHub {
     owner = "EleonoreMizo";
     repo = pname;
     rev = version;
-    sha256 = "1nvanskvh8qv45h7islwgnyrvdkcn7h9jks5fskg4c00aj6bxrrn";
+    sha256 = "sha256-V2iY8mBIFtkLkiHXlN/KrlBmzCEpGStHYaOcJSTU9LE=";
   };
 
   preAutoreconf = "cd build/unix";

--- a/plugins/fvsfunc/default.nix
+++ b/plugins/fvsfunc/default.nix
@@ -1,4 +1,4 @@
-{ lib, vapoursynthPlugins, buildPythonPackage, fetchFromGitHub, python3, vapoursynth }:
+{ lib, vapoursynthPlugins, buildPythonPackage, fetchFromGitHub, python, vapoursynth }:
 let
   propagatedBinaryPlugins = with vapoursynthPlugins; [
     bilateral
@@ -29,12 +29,12 @@ buildPythonPackage rec {
   format = "other";
 
   installPhase = ''
-    install -D fvsfunc.py $out/${python3.sitePackages}/fvsfunc.py
+    install -D fvsfunc.py $out/${python.sitePackages}/fvsfunc.py
   '';
 
   checkInputs = [ (vapoursynth.withPlugins propagatedBinaryPlugins) ];
   checkPhase = ''
-    PYTHONPATH=$out/${python3.sitePackages}:$PYTHONPATH
+    PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
   '';
   pythonImportsCheck = [ "fvsfunc" ];
 

--- a/plugins/havsfunc/default.nix
+++ b/plugins/havsfunc/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, vapoursynthPlugins, python3, vapoursynth }:
+{ lib, buildPythonPackage, fetchFromGitHub, vapoursynthPlugins, python, vapoursynth }:
 
 buildPythonPackage rec {
   pname = "havsfunc";
@@ -41,12 +41,12 @@ buildPythonPackage rec {
   format = "other";
 
   installPhase = ''
-    install -D havsfunc.py $out/${python3.sitePackages}/havsfunc.py
+    install -D havsfunc.py $out/${python.sitePackages}/havsfunc.py
   '';
 
   checkInputs = [ (vapoursynth.withPlugins propagatedBuildInputs) ];
   checkPhase = ''
-    PYTHONPATH=$out/${python3.sitePackages}:$PYTHONPATH
+    PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
   '';
   pythonImportsCheck = [ "havsfunc" ];
 

--- a/plugins/havsfunc/default.nix
+++ b/plugins/havsfunc/default.nix
@@ -28,6 +28,7 @@ buildPythonPackage rec {
     fmtconv
     hqdn3d
     knlmeanscl
+    miscfilters-obsolete
     mvsfunc
     mvtools
     nnedi3

--- a/plugins/imwri/default.nix
+++ b/plugins/imwri/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, imagemagick, libheif, vapoursynth }:
+
+stdenv.mkDerivation rec {
+  pname = "vs-imwri";
+  version = "R1";
+
+  src = fetchFromGitHub {
+    owner = "vapoursynth";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-3nNX7OxAwHPJ6JwaTZJTH13eWktPI/XBmEC/OETCun4=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+  buildInputs = [ imagemagick libheif vapoursynth ];
+
+  postPatch = ''
+    substituteInPlace meson.build \
+        --replace "vapoursynth_dep.get_variable(pkgconfig: 'libdir')" "get_option('libdir')"
+  '';
+
+  meta = with lib; {
+    description = "Image reader and writer for VapourSynth using the ImageMagick library";
+    homepage = "https://github.com/vapoursynth/vs-imwri";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ sbruder ];
+    platforms = platforms.all;
+  };
+}

--- a/plugins/kagefunc/default.nix
+++ b/plugins/kagefunc/default.nix
@@ -1,4 +1,4 @@
-{ lib, vapoursynthPlugins, buildPythonPackage, fetchFromGitHub, python3, vapoursynth }:
+{ lib, vapoursynthPlugins, buildPythonPackage, fetchFromGitHub, python, vapoursynth }:
 let
   propagatedBinaryPlugins = with vapoursynthPlugins; [
     adaptivegrain
@@ -36,12 +36,12 @@ buildPythonPackage rec {
   format = "other";
 
   installPhase = ''
-    install -D kagefunc.py $out/${python3.sitePackages}/kagefunc.py
+    install -D kagefunc.py $out/${python.sitePackages}/kagefunc.py
   '';
 
   checkInputs = [ (vapoursynth.withPlugins propagatedBinaryPlugins) ];
   checkPhase = ''
-    PYTHONPATH=$out/${python3.sitePackages}:$PYTHONPATH
+    PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
     python3 tests.py
   '';
   pythonImportsCheck = [ "kagefunc" ];

--- a/plugins/kagefunc/default.nix
+++ b/plugins/kagefunc/default.nix
@@ -14,13 +14,13 @@ let
 in
 buildPythonPackage rec {
   pname = "kagefunc";
-  version = "unstable-2021-01-21";
+  version = "0.1.0";
 
   src = fetchFromGitHub {
     owner = "Irrational-Encoding-Wizardry";
     repo = pname;
-    rev = "a1e89b1dd591bafec3b9f95e0087b096b9b6f9b1";
-    sha256 = "0j7n7iz0ksqydjm3jzk2l71a77l9ljm71wg414amdqjcbm5dmsw5";
+    rev = version;
+    sha256 = "sha256-9OpFSVLQspa6+xkCFqD5xeo3akCfwnpwtFuCCsQxAvQ=";
   };
 
   patches = [

--- a/plugins/lvsfunc/default.nix
+++ b/plugins/lvsfunc/default.nix
@@ -1,4 +1,4 @@
-{ lib, vapoursynthPlugins, buildPythonPackage, fetchFromGitHub, rich, toolz, vapoursynth }:
+{ lib, vapoursynthPlugins, buildPythonPackage, fetchFromGitHub, rich, toolz, vapoursynth, pythonOlder }:
 let
   propagatedBinaryPlugins = with vapoursynthPlugins; [
     adaptivegrain
@@ -19,13 +19,13 @@ let
 in
 buildPythonPackage rec {
   pname = "lvsfunc";
-  version = "unstable-2021-05-15";
+  version = "0.4.2";
 
   src = fetchFromGitHub {
     owner = "Irrational-Encoding-Wizardry";
     repo = pname;
-    rev = "76bddb75bc014a47064958beecb13143b8206fa6";
-    sha256 = "0gvpz9d0lbjvpk8spkfxbmi4s8pqqyjqi8jjvfhfdf3m906v1wh1";
+    rev = "v${version}";
+    sha256 = "sha256-Yv7WBr9suuYsDI9LfZVcTBuDTPkd/DMCk/lQ58qsLyw=";
   };
 
   postPatch = ''
@@ -33,10 +33,6 @@ buildPythonPackage rec {
     # vapoursynth).
     substituteInPlace requirements.txt \
         --replace "VapourSynth>=51" "" \
-
-    # TODO: remove when python 3.9 is default in nixpkgs
-    substituteInPlace setup.py \
-        --replace "python_requires='>=3.9'" "python_requires='>=3.8'" \
   '';
 
   propagatedBuildInputs = [
@@ -61,5 +57,6 @@ buildPythonPackage rec {
     license = licenses.mit; # no license
     maintainers = with maintainers; [ sbruder ];
     platforms = platforms.all;
+    broken = pythonOlder "3.10";
   };
 }

--- a/plugins/miscfilters-obsolete/default.nix
+++ b/plugins/miscfilters-obsolete/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, tesseract, vapoursynth }:
+
+stdenv.mkDerivation rec {
+  pname = "vs-miscfilters-obsolete";
+  version = "unstable-2022-01-24";
+
+  src = fetchFromGitHub {
+    owner = "vapoursynth";
+    repo = pname;
+    rev = "07e0589a381f7deb3bf533bb459a94482bccc5c7";
+    sha256 = "sha256-WEhpBTNEamNfrNXZxtpTGsOclPMRu+yBzNJmDnU0wzQ=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+  buildInputs = [ vapoursynth ];
+
+  postPatch = ''
+    substituteInPlace meson.build \
+        --replace "dep.get_pkgconfig_variable('libdir')" "get_option('libdir')"
+  '';
+
+  meta = with lib; {
+    description = "A collection of VapourSynth filters that mostly are useful for Avisynth compatibility";
+    homepage = "https://github.com/vapoursynth/vs-miscfilters-obsolete";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ sbruder ];
+    platforms = platforms.all;
+  };
+}

--- a/plugins/mt_lutspa/0001-Use-vs.core-instead-of-vs.get_core.patch
+++ b/plugins/mt_lutspa/0001-Use-vs.core-instead-of-vs.get_core.patch
@@ -1,0 +1,30 @@
+From 6c741ced6ad6b509bde7d6a365c8981539d211f5 Mon Sep 17 00:00:00 2001
+From: Simon Bruder <simon@sbruder.de>
+Date: Tue, 12 Oct 2021 21:31:39 +0200
+Subject: [PATCH] Use vs.core instead of vs.get_core()
+
+It has been deprecated since R51 and was entirely removed in R55.
+---
+ mt_lutspa.py | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/mt_lutspa.py b/mt_lutspa.py
+index d5a51dc..d6a1d85 100644
+--- a/mt_lutspa.py
++++ b/mt_lutspa.py
+@@ -237,10 +237,10 @@ def lutspa(clip, mode="relative", relative=True, biased=True, expr="x",
+ 
+         return frame
+ 
+-    return vs.get_core().std.ModifyFrame(clip, clip, lutspa_core)
++    return vs.core.std.ModifyFrame(clip, clip, lutspa_core)
+ 
+ 
+-core = vs.get_core()
++core = vs.core
+ blank = core.std.BlankClip(width=848, height=480, length=250, format=vs.YUV420P8)
+ out = lutspa(blank, mode="relative", y_expr="x 0.5 > x 255 * y 255 * &u x y max 255 * ?",
+              expr="x 255 * y 255 * &u 112 max 144 min",
+-- 
+2.31.1
+

--- a/plugins/mt_lutspa/default.nix
+++ b/plugins/mt_lutspa/default.nix
@@ -10,6 +10,10 @@ buildPythonPackage rec {
     sha256 = "0szws6fcrcgdn31szhrmglpl2kglrglx1bgxd0bjl3r51bxiry12";
   };
 
+  patches = [
+    ./0001-Use-vs.core-instead-of-vs.get_core.patch
+  ];
+
   propagatedBuildInputs = [
     numpy
   ];

--- a/plugins/mt_lutspa/default.nix
+++ b/plugins/mt_lutspa/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchgit, numpy, vapoursynthPlugins, python3, vapoursynth }:
+{ lib, buildPythonPackage, fetchgit, numpy, vapoursynthPlugins, python, vapoursynth }:
 
 buildPythonPackage rec {
   pname = "mt_lutspa";
@@ -21,12 +21,12 @@ buildPythonPackage rec {
   format = "other";
 
   installPhase = ''
-    install -D mt_lutspa.py $out/${python3.sitePackages}/mt_lutspa.py
+    install -D mt_lutspa.py $out/${python.sitePackages}/mt_lutspa.py
   '';
 
   checkInputs = [ vapoursynth ];
   checkPhase = ''
-    PYTHONPATH=$out/${python3.sitePackages}:$PYTHONPATH
+    PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
   '';
   pythonImportsCheck = [ "mt_lutspa" ];
 

--- a/plugins/muvsfunc/default.nix
+++ b/plugins/muvsfunc/default.nix
@@ -1,4 +1,4 @@
-{ lib, vapoursynthPlugins, buildPythonPackage, fetchFromGitHub, matplotlib, python3, vapoursynth }:
+{ lib, vapoursynthPlugins, buildPythonPackage, fetchFromGitHub, matplotlib, python, vapoursynth }:
 let
   propagatedBinaryPlugins = with vapoursynthPlugins; [
     descale
@@ -30,12 +30,12 @@ buildPythonPackage rec {
   format = "other";
 
   installPhase = ''
-    install -D muvsfunc.py $out/${python3.sitePackages}/muvsfunc.py
+    install -D muvsfunc.py $out/${python.sitePackages}/muvsfunc.py
   '';
 
   checkInputs = [ (vapoursynth.withPlugins propagatedBinaryPlugins) ];
   checkPhase = ''
-    PYTHONPATH=$out/${python3.sitePackages}:$PYTHONPATH
+    PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
   '';
   pythonImportsCheck = [ "muvsfunc" ];
 

--- a/plugins/mvsfunc/default.nix
+++ b/plugins/mvsfunc/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "mvsfunc";
-  version = "r8";
+  version = "r10";
 
   src = fetchFromGitHub {
     owner = "HomeOfVapourSynthEvolution";
     repo = pname;
     rev = version;
-    sha256 = "0y5whczp3skbfbv9ajizddpg2k8hxiiy339gkqhiqby7zlbnvdw2";
+    sha256 = "sha256-J68NMBE3MdAd9P0UJH32o0YwQx+7I5+13j8Jc5rbQtc=";
   };
 
   propagatedBuildInputs = with vapoursynthPlugins; [

--- a/plugins/mvsfunc/default.nix
+++ b/plugins/mvsfunc/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, vapoursynthPlugins, python3, vapoursynth }:
+{ lib, buildPythonPackage, fetchFromGitHub, vapoursynthPlugins, python, vapoursynth }:
 
 buildPythonPackage rec {
   pname = "mvsfunc";
@@ -19,12 +19,12 @@ buildPythonPackage rec {
   format = "other";
 
   installPhase = ''
-    install -D mvsfunc.py $out/${python3.sitePackages}/mvsfunc.py
+    install -D mvsfunc.py $out/${python.sitePackages}/mvsfunc.py
   '';
 
   checkInputs = [ (vapoursynth.withPlugins propagatedBuildInputs) ];
   checkPhase = ''
-    PYTHONPATH=$out/${python3.sitePackages}:$PYTHONPATH
+    PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
   '';
   pythonImportsCheck = [ "mvsfunc" ];
 

--- a/plugins/nnedi3_resample/default.nix
+++ b/plugins/nnedi3_resample/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, vapoursynthPlugins, python3, vapoursynth }:
+{ lib, buildPythonPackage, fetchFromGitHub, vapoursynthPlugins, python, vapoursynth }:
 
 buildPythonPackage rec {
   pname = "nnedi3_resample";
@@ -20,12 +20,12 @@ buildPythonPackage rec {
   format = "other";
 
   installPhase = ''
-    install -D nnedi3_resample.py $out/${python3.sitePackages}/nnedi3_resample.py
+    install -D nnedi3_resample.py $out/${python.sitePackages}/nnedi3_resample.py
   '';
 
   checkInputs = [ (vapoursynth.withPlugins propagatedBuildInputs) ];
   checkPhase = ''
-    PYTHONPATH=$out/${python3.sitePackages}:$PYTHONPATH
+    PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
   '';
   pythonImportsCheck = [ "nnedi3_resample" ];
 

--- a/plugins/nnedi3_rpow2/default.nix
+++ b/plugins/nnedi3_rpow2/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchgit, vapoursynthPlugins, python3, vapoursynth }:
+{ lib, buildPythonPackage, fetchgit, vapoursynthPlugins, python, vapoursynth }:
 
 buildPythonPackage rec {
   pname = "nnedi3_rpow2";
@@ -20,12 +20,12 @@ buildPythonPackage rec {
   format = "other";
 
   installPhase = ''
-    install -D nnedi3_rpow2.py $out/${python3.sitePackages}/nnedi3_rpow2.py
+    install -D nnedi3_rpow2.py $out/${python.sitePackages}/nnedi3_rpow2.py
   '';
 
   checkInputs = [ (vapoursynth.withPlugins propagatedBuildInputs) ];
   checkPhase = ''
-    PYTHONPATH=$out/${python3.sitePackages}:$PYTHONPATH
+    PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
   '';
   pythonImportsCheck = [ "nnedi3_rpow2" ];
 

--- a/plugins/ocr/default.nix
+++ b/plugins/ocr/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, tesseract, vapoursynth }:
+
+stdenv.mkDerivation rec {
+  pname = "vs-ocr";
+  version = "unstable-2021-09-26";
+
+  src = fetchFromGitHub {
+    owner = "vapoursynth";
+    repo = pname;
+    rev = "b5dd7749a2f0694840d287f0bf4d42ce5323a8cf";
+    sha256 = "sha256-N2+S4YRMzjpFdRnCXGgvxU1rUKIjmHe7ylzBrB4CPL8=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+  buildInputs = [ tesseract vapoursynth ];
+
+  postPatch = ''
+    substituteInPlace meson.build \
+        --replace "vapoursynth_dep.get_pkgconfig_variable('libdir')" "get_option('libdir')"
+  '';
+
+  meta = with lib; {
+    description = "OCR plugin for VapourSynth";
+    homepage = "https://github.com/vapoursynth/vs-ocr";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sbruder ];
+    platforms = platforms.all;
+  };
+}

--- a/plugins/placebo/default.nix
+++ b/plugins/placebo/default.nix
@@ -2,27 +2,15 @@
 
 stdenv.mkDerivation rec {
   pname = "vs-placebo";
-  version = "1.3.1";
+  version = "1.4.2";
 
   src = fetchFromGitHub {
     owner = "Lypheo";
     repo = pname;
     rev = version;
-    sha256 = "079i4ixm6273gy9x80ij7s645v5bm53vczkky5lg4vls5sk00hk2";
+    sha256 = "sha256-nerS1z/Ch/UqcmcY2gNL1Xl3hs1/etEAODj8pzrSuEE=";
     fetchSubmodules = true;
   };
-
-  patches = [
-    # fix build with newer libplacebo
-    (fetchpatch {
-      url = "https://github.com/Lypheo/vs-placebo/commit/d717bb49ce03ea9d67152a7c2e4df026de040c35.diff";
-      sha256 = "0phnhpv7alxyw4ki3kj3a19j8qv16hww6gz06lyiyabj20xqibri";
-    })
-    (fetchpatch {
-      url = "https://github.com/Lypheo/vs-placebo/commit/6a99aa1c427f9119d695d3e9d1a08782f51740d1.diff";
-      sha256 = "1x7by89vc0368p4baqlyqi5kw38plr024g4kxbr6afg4f8q4rl58";
-    })
-  ];
 
   nativeBuildInputs = [ meson ninja pkg-config ];
   buildInputs = [ libplacebo vapoursynth vulkan-headers vulkan-loader ];

--- a/plugins/removegrain/default.nix
+++ b/plugins/removegrain/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, vapoursynth }:
+
+stdenv.mkDerivation rec {
+  pname = "vs-removegrain";
+  version = "unstable-2021-09-27";
+
+  src = fetchFromGitHub {
+    owner = "vapoursynth";
+    repo = pname;
+    rev = "ea3d1566b7d82e1efb2f30612d6951dc61ebba65";
+    sha256 = "sha256-yg6VSZzkxFLzW/bTNMx0EollzzJtMKxRuwwXBH326aI=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+  buildInputs = [ vapoursynth ];
+
+  postPatch = ''
+    substituteInPlace meson.build \
+        --replace "vapoursynth_dep.get_pkgconfig_variable('libdir')" "get_option('libdir')"
+  '';
+
+  meta = with lib; {
+    description = "VapourSynth port of RemoveGrain and Repair plugins from Avisynth";
+    homepage = "https://github.com/vapoursynth/vs-removegrain";
+    license = with licenses; [ mit unfree wtfpl ]; # only some files have license header
+    maintainers = with maintainers; [ sbruder ];
+    platforms = platforms.all;
+  };
+}

--- a/plugins/subtext/default.nix
+++ b/plugins/subtext/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, ffmpeg, libass, vapoursynth }:
+
+stdenv.mkDerivation rec {
+  pname = "subtext";
+  version = "R3";
+
+  src = fetchFromGitHub {
+    owner = "vapoursynth";
+    repo = pname;
+    rev = version;
+    sha256 = "sha256-Tux8WFbUn4Bt1EL9r+f+Y/av9w9Y23gc79m1JcZWj50=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+  buildInputs = [ ffmpeg libass vapoursynth ];
+
+  postPatch = ''
+    substituteInPlace meson.build \
+        --replace "vapoursynth_dep.get_pkgconfig_variable('libdir')" "get_option('libdir')"
+  '';
+
+  meta = with lib; {
+    description = "Subtitle plugin for VapourSynth based on libass";
+    homepage = "https://github.com/vapoursynth/subtext";
+    license = licenses.mit;
+    maintainers = with maintainers; [ sbruder ];
+    platforms = platforms.all;
+  };
+}

--- a/plugins/vivtc/default.nix
+++ b/plugins/vivtc/default.nix
@@ -1,0 +1,29 @@
+{ lib, stdenv, fetchFromGitHub, meson, ninja, pkg-config, vapoursynth }:
+
+stdenv.mkDerivation rec {
+  pname = "vivtc";
+  version = "unstable-2021-09-26";
+
+  src = fetchFromGitHub {
+    owner = "vapoursynth";
+    repo = pname;
+    rev = "ed56d96d13a2989fc147a1e9faaced959b6b2cd8";
+    sha256 = "sha256-4tevOjXy41yWYIvsvNODVzVlNx5e/Yf1zFK20Q/8RGs=";
+  };
+
+  nativeBuildInputs = [ meson ninja pkg-config ];
+  buildInputs = [ vapoursynth ];
+
+  postPatch = ''
+    substituteInPlace meson.build \
+        --replace "vapoursynth_dep.get_pkgconfig_variable('libdir')" "get_option('libdir')"
+  '';
+
+  meta = with lib; {
+    description = "Field matcher and decimation filter for VapourSynth similar to TIVTC";
+    homepage = "https://github.com/vapoursynth/vivtc";
+    license = licenses.lgpl21Plus;
+    maintainers = with maintainers; [ sbruder ];
+    platforms = platforms.all;
+  };
+}

--- a/plugins/vsTAAmbk/0001-Skip-OpenCL-test.patch
+++ b/plugins/vsTAAmbk/0001-Skip-OpenCL-test.patch
@@ -1,3 +1,12 @@
+From 35b84e26e337a3d8a3cacc5dcfde8d8c81931924 Mon Sep 17 00:00:00 2001
+From: Simon Bruder <simon@sbruder.de>
+Date: Fri, 15 Oct 2021 19:34:45 +0200
+Subject: [PATCH 1/2] Skip OpenCL test
+
+---
+ test/vsTAAmbkTestCase.py | 1 +
+ 1 file changed, 1 insertion(+)
+
 diff --git a/test/vsTAAmbkTestCase.py b/test/vsTAAmbkTestCase.py
 index ca85b73..7a70a00 100644
 --- a/test/vsTAAmbkTestCase.py
@@ -10,3 +19,6 @@ index ca85b73..7a70a00 100644
      def test_opencl(self):
          test_clip = [self.gray8, self.gray16]
          for clip in test_clip:
+-- 
+2.31.1
+

--- a/plugins/vsTAAmbk/0002-Use-format-IDs-from-VapourSynth-R55.patch
+++ b/plugins/vsTAAmbk/0002-Use-format-IDs-from-VapourSynth-R55.patch
@@ -1,0 +1,35 @@
+From cfc284a25d94ddf4459bac612d208f9065ccebcf Mon Sep 17 00:00:00 2001
+From: Simon Bruder <simon@sbruder.de>
+Date: Fri, 15 Oct 2021 19:32:44 +0200
+Subject: [PATCH 2/2] Use format IDs from VapourSynth R55
+
+---
+ test/vsTAAmbkTestCase.py | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/test/vsTAAmbkTestCase.py b/test/vsTAAmbkTestCase.py
+index 7a70a00..d2acdd6 100644
+--- a/test/vsTAAmbkTestCase.py
++++ b/test/vsTAAmbkTestCase.py
+@@ -88,12 +88,12 @@ class GeneralTestCase(unittest.TestCase):
+     yuv420p16 = core.std.BlankClip(width=1920, height=1080, format=vs.YUV420P16, fpsnum=24000, fpsden=1001)
+     yuv444p16 = core.std.BlankClip(width=1920, height=1080, format=vs.YUV444P16, fpsnum=24000, fpsden=1001)
+     format_id = {
+-        '1000010': 'GRAY8',
+-        '1000011': 'GRAY16',
+-        '3000010': 'YUV420P8',
+-        '3000012': 'YUV444P8',
+-        '3000022': 'YUV420P16',
+-        '3000024': 'YUV444P16',
++        '268959744': 'GRAY8',
++        '269484032': 'GRAY16',
++        '805830913': 'YUV420P8',
++        '805830656': 'YUV444P8',
++        '806355201': 'YUV420P16',
++        '806354944': 'YUV444P16',
+     }
+ 
+     def test_default_value(self):
+-- 
+2.31.1
+

--- a/plugins/vsTAAmbk/default.nix
+++ b/plugins/vsTAAmbk/default.nix
@@ -1,4 +1,4 @@
-{ lib, buildPythonPackage, fetchFromGitHub, vapoursynthPlugins, python3, vapoursynth }:
+{ lib, buildPythonPackage, fetchFromGitHub, vapoursynthPlugins, python, vapoursynth }:
 
 buildPythonPackage rec {
   pname = "vsTAAmbk";
@@ -37,12 +37,12 @@ buildPythonPackage rec {
   format = "other";
 
   installPhase = ''
-    install -D vsTAAmbk.py $out/${python3.sitePackages}/vsTAAmbk.py
+    install -D vsTAAmbk.py $out/${python.sitePackages}/vsTAAmbk.py
   '';
 
   checkInputs = [ (vapoursynth.withPlugins propagatedBuildInputs) ];
   checkPhase = ''
-    PYTHONPATH=$out/${python3.sitePackages}:$PYTHONPATH
+    PYTHONPATH=$out/${python.sitePackages}:$PYTHONPATH
     python3 test/vsTAAmbkTestCase.py
   '';
 

--- a/plugins/vsTAAmbk/default.nix
+++ b/plugins/vsTAAmbk/default.nix
@@ -12,7 +12,8 @@ buildPythonPackage rec {
   };
 
   patches = [
-    ./skip-opencl-test.diff
+    ./0001-Skip-OpenCL-test.patch
+    ./0002-Use-format-IDs-from-VapourSynth-R55.patch
   ];
 
   propagatedBuildInputs = with vapoursynthPlugins; [
@@ -27,6 +28,7 @@ buildPythonPackage rec {
     mvtools
     nnedi3
     nnedi3cl
+    removegrain
     sangnom
     tcanny
     znedi3

--- a/plugins/vsTAAmbk/default.nix
+++ b/plugins/vsTAAmbk/default.nix
@@ -2,13 +2,13 @@
 
 buildPythonPackage rec {
   pname = "vsTAAmbk";
-  version = "unstable-2020-08-13";
+  version = "0.8.1";
 
   src = fetchFromGitHub {
     owner = "HomeOfVapourSynthEvolution";
     repo = pname;
-    rev = "4dddf1a86effb4c6ceae7ca493f1ceed434e37ea";
-    sha256 = "06n744b9qr495afrpp4c1i3vcr5cab114rx69xslbhiwy2mg237s";
+    rev = "v${version}";
+    sha256 = "sha256-KfU2f7tBhw007f4RmVruV3Pkgo1zdA4o43+1lL/ohKo=";
   };
 
   patches = [

--- a/plugins/vsutil/default.nix
+++ b/plugins/vsutil/default.nix
@@ -1,15 +1,15 @@
-{ lib, buildPythonPackage, fetchFromGitHub, vapoursynth }:
+{ lib, buildPythonPackage, fetchFromGitHub, fetchpatch, vapoursynth }:
 
 buildPythonPackage rec {
   pname = "vsutil";
-  version = "0.5.0";
+  version = "unstable-2021-10-23";
 
   # there are no tests in the pypi tarball
   src = fetchFromGitHub {
     owner = "Irrational-Encoding-Wizardry";
     repo = pname;
-    rev = version;
-    sha256 = "0pv3910g5cdx132cq9f3g7rb3yxyxyvw9110vsl196xswkccl8n8";
+    rev = "a101f22b7be4f28bc89ed73bfc82cce3067dc549";
+    sha256 = "sha256-IQncZxpd2QNYmjMXxE++yeY4mDffBjOtE69J2lQPQUU=";
   };
 
   patches = [

--- a/tools/getnative/default.nix
+++ b/tools/getnative/default.nix
@@ -7,19 +7,21 @@ let
 in
 buildPythonApplication rec {
   pname = "getnative";
-  version = "3.0.0";
+  version = "3.0.2";
 
   src = fetchFromGitHub {
     owner = "Infiziert90";
     repo = pname;
-    rev = version;
-    sha256 = "0jvvwyxlgarff2r5v2nvqmy2bw17anz4cid95gwbl3br4a2pmhzn";
+    # The version in setup.py is 3.0.2, but there is no tag for it
+    # (the tag that GitHub shows as 3.0.2 actually is 3.0.0)
+    rev = "2ae9037adca5ac1f5d747bb32f4dbea30631dc33";
+    sha256 = "sha256-h3M/eRDwJKaPRedISxW6lzBw5UT20hTLhqmRa4HzQuw=";
   };
 
   # vapoursynth is not recognised during installation
   postPatch = ''
     substituteInPlace requirements.txt \
-        --replace "VapourSynth>=45" ""
+        --replace "VapourSynth>=55" ""
   '';
 
   propagatedBuildInputs = [


### PR DESCRIPTION
Since VapourSynth R55/API v4 changed many things, a lot of plugins do not work any more. This PR addresses this.
It also adds plugins previously bundled with VapourSynth.

While I didn’t test this thoroughly, most plugins seem to work (and all except for those marked as broken build).

This fixes #6 (build error of bm3d that propagated to havsfunc).