### PR TITLE
vapoursynthPlugins.vsgan: init at 1.6.4

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -60,6 +60,7 @@ in
     nnedi3_resample = callPythonPackage ./plugins/nnedi3_resample { };
     nnedi3_rpow2 = callPythonPackage ./plugins/nnedi3_rpow2 { };
     rekt = callPythonPackage ./plugins/rekt { };
+    vsgan = callPythonPackage ./plugins/vsgan { };
     vsTAAmbk = callPythonPackage ./plugins/vsTAAmbk { };
     vsutil = callPythonPackage ./plugins/vsutil { };
 

--- a/plugins/vsgan/default.nix
+++ b/plugins/vsgan/default.nix
@@ -1,0 +1,42 @@
+{ lib,
+  buildPythonPackage,
+  fetchFromGitHub,
+  vapoursynth,
+  poetry,
+  python3Packages
+}:
+
+buildPythonPackage rec {
+  pname = "vsgan";
+  version = "1.6.4";
+
+  src = fetchFromGitHub {
+    owner = "rlaphoenix";
+    repo = "VSGAN";
+    rev = "v${version}";
+    sha256 = "sha256-bMgCah3kkyxNU5tb/eLt0tuG4xnD4sbtAzUK0a4uOKE=";
+  };
+
+  format = "pyproject";
+
+  propagatedBuildInputs = [
+    poetry
+  ] ++ (with python3Packages; [
+    numpy
+    pytorch
+  ]);
+
+  checkInputs = [
+    vapoursynth
+  ];
+
+  pythonImportsCheck = [ "vsgan" ];
+
+  meta = with lib; {
+    description = "ESRGAN for VapourSynth";
+    homepage = "https://vsgan.phoeniix.dev/";
+    license = licenses.mit;
+    maintainers = with maintainers; [ aidalgol ];
+    platforms = platforms.all;
+  };
+}

--- a/plugins/vsgan/default.nix
+++ b/plugins/vsgan/default.nix
@@ -1,9 +1,10 @@
-{ lib,
-  buildPythonPackage,
-  fetchFromGitHub,
-  vapoursynth,
-  poetry,
-  python3Packages
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, vapoursynth
+, numpy
+, poetry
+, pytorch
 }:
 
 buildPythonPackage rec {
@@ -20,11 +21,10 @@ buildPythonPackage rec {
   format = "pyproject";
 
   propagatedBuildInputs = [
-    poetry
-  ] ++ (with python3Packages; [
     numpy
+    poetry
     pytorch
-  ]);
+  ];
 
   checkInputs = [
     vapoursynth


### PR DESCRIPTION
Add VapourSynth plugin [VSGAN](https://vsgan.phoeniix.dev/).  (Using this plugin requires `nixpkgs.config.cudaSupport = true;` in any derivation using this overlay.)