### PR TITLE
Add vstrt plugin

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -60,6 +60,7 @@ in
     tnlmeans = prev.callPackage ./plugins/tnlmeans { };
     ttempsmooth = prev.callPackage ./plugins/ttempsmooth { };
     vivtc = prev.callPackage ./plugins/vivtc { };
+    vstrt = prev.callPackage ./plugins/vstrt { };
     wwxd = prev.callPackage ./plugins/wwxd { };
     znedi3 = prev.callPackage ./plugins/znedi3 { };
 

--- a/default.nix
+++ b/default.nix
@@ -88,4 +88,10 @@ in
   };
 
   getnative = callPythonPackage ./tools/getnative { };
+
+  pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
+    (python-final: python-prev: {
+      styler00dollar-vsgan-trt = callPythonPackage ./tools/styler00dollar-vsgan-trt { };
+    })
+  ];
 }

--- a/plugins/vstrt/default.nix
+++ b/plugins/vstrt/default.nix
@@ -1,0 +1,55 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, cmake
+, vapoursynth
+, cudatoolkit
+, cudaPackages
+}:
+
+stdenv.mkDerivation rec {
+  pname = "vstrt";
+  version = "10";
+
+  src = fetchFromGitHub {
+    owner = "AmusementClub";
+    repo = "vs-mlrt";
+    rev = "v${version}";
+    sha256 = "sha256-fnnVaWPvT/eqr1WEwyhX8zi26IK3Ndm7UHLkSLI1nFk=";
+  };
+
+  sourceRoot = "source/vstrt";
+
+  patches = [
+    ./no-git-call-in-cmake.patch
+  ];
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    vapoursynth
+    cudatoolkit
+    cudaPackages.tensorrt
+  ];
+
+  cmakeFlags = [
+    "-DVCS_TAG=v${version}"
+    "-DCMAKE_CXX_FLAGS=-I${vapoursynth}/include/vapoursynth"
+    "-DCMAKE_SKIP_RPATH=ON"
+  ];
+
+  postInstall = ''
+    mkdir $out/lib/vapoursynth
+    ln -s $out/lib/libvstrt.so $out/lib/vapoursynth
+  '';
+
+  meta = with lib; {
+    description = "TensorRT-based GPU Runtime";
+    homepage = "https://github.com/AmusementClub/vs-mlrt";
+    license = licenses.gpl3;
+    maintainers = with maintainers; [ aidalgol ];
+    platforms = platforms.all;
+  };
+}

--- a/plugins/vstrt/no-git-call-in-cmake.patch
+++ b/plugins/vstrt/no-git-call-in-cmake.patch
@@ -1,0 +1,15 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -61,12 +61,6 @@ target_include_directories(vstrt PUBLIC
+     "${PROJECT_BINARY_DIR}"
+ )
+ 
+-find_package(Git REQUIRED)
+-execute_process(
+-    COMMAND ${GIT_EXECUTABLE} describe --tags --long --always
+-    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+-    OUTPUT_VARIABLE VCS_TAG
+-)
+ string(STRIP ${VCS_TAG} VCS_TAG)
+ configure_file(config.h.in config.h)
+ 

--- a/tools/styler00dollar-vsgan-trt/default.nix
+++ b/tools/styler00dollar-vsgan-trt/default.nix
@@ -1,0 +1,63 @@
+{ lib
+, fetchFromGitHub
+, buildPythonPackage
+, python3
+  # Needed to explicitly get the VapourSynth *Python* package.
+, python3Packages
+, numpy
+, torch
+}:
+
+let
+  pythonPackageName = "styler00dollar";
+in
+buildPythonPackage rec {
+  pname = "styler00dollar-vsgan-trt";
+  version = "unstable-2022-09-19";
+
+  src = fetchFromGitHub {
+    owner = "styler00dollar";
+    repo = "VSGAN-tensorrt-docker";
+    rev = "cf9c45cdacba9f19b25e26d0e4767bcfe5d48db0";
+    sha256 = "sha256-L2HwE5r9OMiuupolJJbvPRIzWIRXc9uDSPC2WTZwWl8=";
+  };
+
+  format = "other";
+
+  propagatedBuildInputs = [
+    numpy
+    torch
+    python3Packages.vapoursynth
+  ];
+
+  postPatch = ''
+    sed --in-place 's/src\./${pythonPackageName}./' convert_*_to_onnx.py
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/${python3.sitePackages}
+    # "src" is the actual name of the subdirectory from upstream.
+    cp -r src $out/${python3.sitePackages}/${pythonPackageName}
+
+    mkdir -p $out/examples
+    cp convert_*_to_onnx.py $out/examples
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "VSGAN utility modules from styler00dollar";
+    longDescription = ''
+      Various utility modules by styler00dollar for working with TensorRT.
+
+      This can be used to convert ESRGAN models to to ONXX models, which is
+      required if you want to use ESRGAN models with TensorRT.
+    '';
+    homepage = "https://github.com/styler00dollar/VSGAN-tensorrt-docker";
+    license = licenses.bsd3;
+    maintainers = with maintainers; [ aidalgol ];
+    platforms = platforms.all;
+  };
+}


### PR DESCRIPTION
Add the [vstrt](https://github.com/AmusementClub/vs-mlrt/tree/master/vstrt) plugin, a faster alternative to VSGAN, as well as some Python utility modules from [styler00dollar/VSGAN-tensorrt-docker](https://github.com/styler00dollar/VSGAN-tensorrt-docker), which compliment this plugin.