### PR TITLE
lsmash: fix build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -41,7 +41,9 @@ in
     hqdn3d = prev.callPackage ./plugins/hqdn3d { };
     imwri = prev.callPackage ./plugins/imwri { };
     knlmeanscl = prev.callPackage ./plugins/knlmeanscl { };
-    lsmashsource = prev.callPackage ./plugins/lsmashsource { };
+    lsmashsource = prev.callPackage ./plugins/lsmashsource {
+      ffmpeg = prev.ffmpeg_4;
+    };
     median = prev.callPackage ./plugins/median { };
     minideen = prev.callPackage ./plugins/minideen { };
     miscfilters-obsolete = prev.callPackage ./plugins/miscfilters-obsolete { };

--- a/everything-shell.nix
+++ b/everything-shell.nix
@@ -46,7 +46,7 @@ in
         pkgs.vapoursynthPlugins.hqdn3d
         pkgs.vapoursynthPlugins.imwri
         pkgs.vapoursynthPlugins.knlmeanscl
-        # pkgs.vapoursynthPlugins.lsmashsource
+        pkgs.vapoursynthPlugins.lsmashsource
         pkgs.vapoursynthPlugins.median
         pkgs.vapoursynthPlugins.minideen
         pkgs.vapoursynthPlugins.miscfilters-obsolete


### PR DESCRIPTION
lsmashsource does not build with any version of ffmpeg after 4, so we need to pin it to that version.